### PR TITLE
chore(docs): Fix typo in table docs

### DIFF
--- a/src/components/table/package.json
+++ b/src/components/table/package.json
@@ -223,7 +223,7 @@
           },
           {
             "prop": "sortCompare",
-            "description": "A reference to a function for sort-comparing tow rows of data. Defaults to the internal sort compare routine. See docs for details"
+            "description": "A reference to a function for sort-comparing two rows of data. Defaults to the internal sort compare routine. See docs for details"
           },
           {
             "prop": "sortCompareOptions",


### PR DESCRIPTION
There was a typo in the `sortCompare` key for the table components meta data inside `package.json`, which is fixed with this commit.

### Describe the PR

Simple typo fix in the table docs

### PR checklist

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement
- [ ] ARIA accessibility
- [x] Documentation update
- [ ] Other (please describe)

**Does this PR introduce a breaking change?** (check one)

- [x] No
- [ ] Yes (please describe)

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch, **not** the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (i.e. `[...] (fixes #xxx[,#xxx])`, where "xxx" is the issue number)
- [x] It should address only one issue or feature. If adding multiple features or fixing a bug and adding a new feature, break them into separate PRs if at all possible.
- [x] The title should follow the [**Conventional Commits**](https://www.conventionalcommits.org/) naming convention (i.e. `fix(alert): not alerting during SSR render`, `docs(badge): update pill examples`, `chore(docs): fix typo in README`, etc).